### PR TITLE
krb5-user package for kerberos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV SP_CERT_DIRS="/etc/shibboleth" \
 
 WORKDIR /app
 
-RUN install_packages curl runit apache2 openssl ca-certificates \
+RUN install_packages curl runit apache2 openssl ca-certificates krb5-user \
     libapache2-mod-shib libapache2-mod-auth-gssapi libapache2-mod-auth-openidc libapache2-mod-auth-cas && \
     mkdir -p /run/shibboleth && chmod 0755 /run/shibboleth && chown _shibd /run/shibboleth && \
     mkdir -p /var/shibboleth && chmod 0755 /run/shibboleth && chown _shibd /run/shibboleth && \


### PR DESCRIPTION
I forgot to add krb5-user package to auth_gssapi pull request. Some of the gssapi features requires this.