### PR TITLE
Cleanup dangling pid/socket files on startup

### DIFF
--- a/etcfs/scripts/90_cleanup
+++ b/etcfs/scripts/90_cleanup
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+POSSIBLE_DANGLING_FILES=( /var/run/apache2/apache2.pid /var/run/shibboleth/shibd.sock )
+
+for DANGLING_FILE in "${POSSIBLE_DANGLING_FILES[@]}"
+do
+	if [[ -n "$DANGLING_FILE" && -f $DANGLING_FILE ]]; then
+		rm -f $DANGLING_FILE
+		echo "Removed dangling file $DANGLING_FILE"
+	fi
+done


### PR DESCRIPTION
Sometimes ie. if the docker host restarts  abruptly or the services fails to shutdown gracefully on container stop grace period there is dangling socket and pid files left inside the container and the services fails to start on restart.
This adds cleanup script that removes dangling files on startup.     