### PR TITLE
Update minideb base image to Debian 13 “trixie”

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/minideb:bookworm
+FROM bitnami/minideb:trixie
 
 LABEL description="A simple, unconfigured Apache reverse proxy service including the Shibboleth SP module" \
       maintainer="pete@digitalidentitylabs.com" \


### PR DESCRIPTION
This updates the minideb base image to Debian 13 "trixie" which also updates Apache to 2.4.65 which fixes multiple CVEs (https://httpd.apache.org/security/vulnerabilities_24.html) found in 2.4.62.